### PR TITLE
Fix peer dependency for eslint-plugin-import

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "babel-preset-react-native": "1.9.0",
     "eslint": "3.6.0",
     "eslint-config-airbnb": "12.0.0",
-    "eslint-plugin-import": "2.0.1",
+    "eslint-plugin-import": "1.16.0",
     "eslint-plugin-jsx-a11y": "2.2.3",
     "eslint-plugin-react": "6.4.1"
   }


### PR DESCRIPTION
`eslint-plugin-import` has a peer dependency on 1.16.0.

```
npm WARN eslint-config-airbnb@12.0.0 requires a peer of eslint-plugin-import@^1.16.0 but none was installed.
```

Not sure if it's affected anything with `eslint-config-airbnb`, but at the least removes a warning when installing from npm.